### PR TITLE
Add SEO metadata + JSON-LD for shipyard.company

### DIFF
--- a/website/src/app/about/page.tsx
+++ b/website/src/app/about/page.tsx
@@ -3,6 +3,17 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "About — Shipyard AI",
   description: "Meet the autonomous agent team that builds your Emdash products.",
+  openGraph: {
+    title: "About — Shipyard AI",
+    description: "The first autonomous AI agency built for Emdash. AI agents that debate, build, and ship.",
+    url: "https://shipyard.company/about",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "About — Shipyard AI",
+    description: "The first autonomous AI agency built for Emdash. AI agents that debate, build, and ship.",
+  },
 };
 
 const agents = [

--- a/website/src/app/contact/page.tsx
+++ b/website/src/app/contact/page.tsx
@@ -2,8 +2,19 @@ import type { Metadata } from "next";
 import { ContactForm } from "./ContactForm";
 
 export const metadata: Metadata = {
-  title: "Start a Project — Shipyard AI",
+  title: "Submit a PRD — Shipyard AI",
   description: "Submit your PRD and we'll scope it, quote tokens, and start building.",
+  openGraph: {
+    title: "Submit a PRD — Shipyard AI",
+    description: "Submit your PRD and we'll build your Emdash site, theme, or plugin.",
+    url: "https://shipyard.company/contact",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Submit a PRD — Shipyard AI",
+    description: "Submit your PRD and we'll build your Emdash site, theme, or plugin.",
+  },
 };
 
 export default function ContactPage() {

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -15,9 +15,24 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://shipyard.company"),
   title: "Shipyard AI — PRD to Production",
   description:
     "Autonomous AI agency that builds Emdash sites, themes, and plugins from PRDs. Ship production-quality digital products at machine speed.",
+  openGraph: {
+    title: "Shipyard AI — PRD to Production",
+    description:
+      "Autonomous AI agency that builds Emdash sites, themes, and plugins from PRDs.",
+    url: "https://shipyard.company",
+    siteName: "Shipyard AI",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Shipyard AI — PRD to Production",
+    description:
+      "Autonomous AI agency that builds Emdash sites, themes, and plugins from PRDs.",
+  },
 };
 
 function Header() {
@@ -87,6 +102,28 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="flex min-h-full flex-col">
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "Organization",
+              name: "Shipyard AI",
+              url: "https://shipyard.company",
+              description:
+                "Autonomous AI agency that builds Emdash sites, themes, and plugins from PRDs.",
+              foundingDate: "2026",
+              knowsAbout: [
+                "EmDash",
+                "Astro",
+                "Cloudflare",
+                "Web Development",
+                "AI Agents",
+                "CMS",
+              ],
+            }),
+          }}
+        />
         <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:bg-accent focus:px-4 focus:py-2 focus:text-black">
           Skip to main content
         </a>

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -1,4 +1,21 @@
 import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Shipyard AI — PRD to Production",
+  description: "Autonomous AI agency that builds Emdash sites, themes, and plugins from PRDs.",
+  openGraph: {
+    title: "Shipyard AI — PRD to Production",
+    description: "Autonomous AI agency that builds Emdash sites, themes, and plugins from PRDs.",
+    url: "https://shipyard.company",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Shipyard AI — PRD to Production",
+    description: "Autonomous AI agency that builds Emdash sites, themes, and plugins from PRDs.",
+  },
+};
 
 function HeroSection() {
   return (

--- a/website/src/app/pipeline/page.tsx
+++ b/website/src/app/pipeline/page.tsx
@@ -4,6 +4,17 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Pipeline — Shipyard AI",
   description: "Six stages from PRD to production. See exactly how your project gets built.",
+  openGraph: {
+    title: "Pipeline — Shipyard AI",
+    description: "How Shipyard AI turns PRDs into production: intake, debate, plan, build, review, deploy.",
+    url: "https://shipyard.company/pipeline",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Pipeline — Shipyard AI",
+    description: "How Shipyard AI turns PRDs into production: intake, debate, plan, build, review, deploy.",
+  },
 };
 
 const stages = [

--- a/website/src/app/services/page.tsx
+++ b/website/src/app/services/page.tsx
@@ -4,6 +4,17 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Services — Shipyard AI",
   description: "Emdash sites, themes, and plugins built from PRDs with transparent token-based pricing.",
+  openGraph: {
+    title: "Services — Shipyard AI",
+    description: "Emdash sites, themes, and plugins. Built by AI agents, deployed to production.",
+    url: "https://shipyard.company/services",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Services — Shipyard AI",
+    description: "Emdash sites, themes, and plugins. Built by AI agents, deployed to production.",
+  },
 };
 
 const tiers = [


### PR DESCRIPTION
## Summary
- Set metadataBase to https://shipyard.company across all pages
- Add Open Graph and Twitter card tags to root layout + all 5 subpages
- Add Organization JSON-LD structured data to root layout
- Build verified — all pages render correctly

## Test plan
- [ ] `npm run build` passes
- [ ] OG tags visible in page source for all routes
- [ ] JSON-LD script tag present in HTML head
- [ ] Vercel auto-deploy picks up merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)