### PR TITLE
Wire contact form to Resend via Cloudflare Worker

### DIFF
--- a/website/src/app/contact/ContactForm.tsx
+++ b/website/src/app/contact/ContactForm.tsx
@@ -6,7 +6,7 @@ export function ContactForm() {
   const [state, setState] = useState<{ success: boolean; message: string } | null>(null);
   const [pending, setPending] = useState(false);
 
-  function handleSubmit(e: FormEvent<HTMLFormElement>) {
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const form = e.currentTarget;
     const data = new FormData(form);
@@ -32,20 +32,24 @@ export function ContactForm() {
       return;
     }
 
+    const budget = (data.get("budget") as string) || "";
+
     setPending(true);
 
-    // Compose mailto with form data
-    const subject = encodeURIComponent(`PRD Submission: ${projectType} from ${name}`);
-    const body = encodeURIComponent(
-      `Name: ${name}\nEmail: ${email}\nProject Type: ${projectType}\n\nDescription:\n${description}`
-    );
-    window.location.href = `mailto:hello@shipyard.company?subject=${subject}&body=${body}`;
-
-    setTimeout(() => {
+    try {
+      const res = await fetch("https://shipyard-contact.seth-a02.workers.dev/submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, email, projectType, budget, description }),
+      });
+      const result = await res.json();
+      setState({ success: result.success, message: result.message });
+      if (result.success) form.reset();
+    } catch {
+      setState({ success: false, message: "Network error. Please email us directly at hello@shipyard.company." });
+    } finally {
       setPending(false);
-      setState({ success: true, message: "Thanks! Your email client should have opened. We'll scope your project and respond within 24 hours." });
-      form.reset();
-    }, 1000);
+    }
   }
 
   return (

--- a/workers/contact-form/.wrangler/cache/wrangler-account.json
+++ b/workers/contact-form/.wrangler/cache/wrangler-account.json
@@ -1,0 +1,6 @@
+{
+  "account": {
+    "id": "a02352ad1742197c106c1774fcbada2d",
+    "name": ""
+  }
+}

--- a/workers/contact-form/src/index.ts
+++ b/workers/contact-form/src/index.ts
@@ -1,0 +1,131 @@
+/**
+ * Shipyard AI — Contact Form Worker
+ *
+ * Cloudflare Worker that receives form submissions and sends
+ * them via Resend. Deployed separately from the static site.
+ *
+ * POST /submit — accepts JSON { name, email, projectType, budget, description }
+ * Returns 200 on success, 400/500 on error.
+ */
+
+interface Env {
+  RESEND_API_KEY: string;
+  FROM_EMAIL: string;
+  TO_EMAIL: string;
+  CORS_ORIGIN: string;
+}
+
+interface ContactPayload {
+  name: string;
+  email: string;
+  projectType: string;
+  budget: string;
+  description: string;
+  website?: string; // honeypot
+}
+
+function corsHeaders(origin: string): Record<string, string> {
+  return {
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  };
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const headers = corsHeaders(env.CORS_ORIGIN);
+
+    // Handle CORS preflight
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers });
+    }
+
+    if (request.method !== "POST") {
+      return new Response(JSON.stringify({ error: "Method not allowed" }), {
+        status: 405,
+        headers: { ...headers, "Content-Type": "application/json" },
+      });
+    }
+
+    try {
+      const body: ContactPayload = await request.json();
+
+      // Honeypot check
+      if (body.website) {
+        return new Response(
+          JSON.stringify({ success: true, message: "Thanks! We'll be in touch within 24 hours." }),
+          { status: 200, headers: { ...headers, "Content-Type": "application/json" } }
+        );
+      }
+
+      // Validate required fields
+      if (!body.name?.trim() || !body.email?.trim() || !body.description?.trim()) {
+        return new Response(
+          JSON.stringify({ success: false, message: "Please fill in all required fields." }),
+          { status: 400, headers: { ...headers, "Content-Type": "application/json" } }
+        );
+      }
+
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(body.email)) {
+        return new Response(
+          JSON.stringify({ success: false, message: "Please enter a valid email address." }),
+          { status: 400, headers: { ...headers, "Content-Type": "application/json" } }
+        );
+      }
+
+      // Send via Resend
+      const resendResponse = await fetch("https://api.resend.com/emails", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${env.RESEND_API_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          from: `Shipyard AI <${env.FROM_EMAIL}>`,
+          to: [env.TO_EMAIL],
+          reply_to: body.email,
+          subject: `New PRD: ${body.projectType} from ${body.name}`,
+          html: `
+            <h2>New PRD Submission</h2>
+            <table style="border-collapse:collapse;width:100%;max-width:600px;">
+              <tr><td style="padding:8px;font-weight:bold;border-bottom:1px solid #eee;">Name</td><td style="padding:8px;border-bottom:1px solid #eee;">${escapeHtml(body.name)}</td></tr>
+              <tr><td style="padding:8px;font-weight:bold;border-bottom:1px solid #eee;">Email</td><td style="padding:8px;border-bottom:1px solid #eee;"><a href="mailto:${escapeHtml(body.email)}">${escapeHtml(body.email)}</a></td></tr>
+              <tr><td style="padding:8px;font-weight:bold;border-bottom:1px solid #eee;">Project Type</td><td style="padding:8px;border-bottom:1px solid #eee;">${escapeHtml(body.projectType)}</td></tr>
+              <tr><td style="padding:8px;font-weight:bold;border-bottom:1px solid #eee;">Budget</td><td style="padding:8px;border-bottom:1px solid #eee;">${escapeHtml(body.budget || "Not specified")}</td></tr>
+            </table>
+            <h3 style="margin-top:24px;">Project Description / PRD</h3>
+            <div style="background:#f5f5f5;padding:16px;border-radius:8px;white-space:pre-wrap;">${escapeHtml(body.description)}</div>
+          `,
+        }),
+      });
+
+      if (!resendResponse.ok) {
+        const err = await resendResponse.text();
+        console.error("Resend error:", err);
+        return new Response(
+          JSON.stringify({ success: false, message: "Failed to send. Please email us directly at hello@shipyard.company." }),
+          { status: 500, headers: { ...headers, "Content-Type": "application/json" } }
+        );
+      }
+
+      return new Response(
+        JSON.stringify({ success: true, message: "Thanks! We'll scope your project and respond within 24 hours." }),
+        { status: 200, headers: { ...headers, "Content-Type": "application/json" } }
+      );
+    } catch {
+      return new Response(
+        JSON.stringify({ success: false, message: "Invalid request." }),
+        { status: 400, headers: { ...headers, "Content-Type": "application/json" } }
+      );
+    }
+  },
+};
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/workers/contact-form/wrangler.toml
+++ b/workers/contact-form/wrangler.toml
@@ -1,0 +1,8 @@
+name = "shipyard-contact"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+
+[vars]
+FROM_EMAIL = "hello@shipyard.company"
+TO_EMAIL = "seth@caseproof.com"
+CORS_ORIGIN = "https://shipyard.company"


### PR DESCRIPTION
## Summary
- Cloudflare Worker (`shipyard-contact`) sends form submissions via Resend
- ContactForm updated to POST JSON to Worker instead of mailto
- Worker handles validation, honeypot, HTML email formatting
- Site remains fully static

## Test plan
- [ ] Submit form on /contact → email arrives at seth@caseproof.com
- [ ] Invalid email shows error
- [ ] Empty fields show error
- [ ] Honeypot silently rejects bots

🤖 Generated with [Claude Code](https://claude.com/claude-code)