### PR TITLE
CI/CD: Cloudflare Pages Deploy Pipeline

### DIFF
--- a/pipeline/deploy/README.md
+++ b/pipeline/deploy/README.md
@@ -1,0 +1,149 @@
+# Deploy Pipeline — EmDash to Cloudflare Pages
+
+This directory contains the Cloudflare Pages deployment pipeline for EmDash sites built by Shipyard AI.
+
+## Overview
+
+EmDash sites are built with Astro 6 and Cloudflare Workers, running on Cloudflare Pages. The deploy pipeline automates:
+
+1. **Build validation** — Ensures site directory exists, dependencies are installed, Node version is compatible
+2. **Astro build** — Generates static/server-rendered output via `astro build`
+3. **Project setup** — Creates the Cloudflare Pages project if it doesn't exist
+4. **Deployment** — Pushes the built site to Cloudflare Pages via Wrangler
+5. **URL output** — Returns the live production URL
+
+## Deploy Scripts
+
+### `deploy.sh` — Deploy a single site
+
+Deploys an EmDash site to Cloudflare Pages.
+
+**Usage:**
+```bash
+./pipeline/deploy/deploy.sh <site-directory> <project-name>
+```
+
+**Example:**
+```bash
+./pipeline/deploy/deploy.sh ./examples/bellas-bistro bellas-bistro
+```
+
+**Requirements:**
+- `CLOUDFLARE_API_TOKEN` environment variable (Cloudflare API token with Pages deploy permissions)
+- `CLOUDFLARE_ACCOUNT_ID` environment variable (Cloudflare account ID)
+- Node.js >= 22
+- Wrangler CLI (installed via npm)
+
+**Steps:**
+1. Validates site directory exists
+2. Checks Node version >= 22
+3. Installs dependencies if `node_modules` missing
+4. Builds with `npx astro build`
+5. Checks if Cloudflare Pages project exists; creates if needed
+6. Deploys to Cloudflare Pages with branch name `main`
+7. Outputs the live URL
+
+### `deploy-all.sh` — Deploy all example sites
+
+Deploys all EmDash sites in the `examples/` directory to Cloudflare Pages.
+
+**Usage:**
+```bash
+./pipeline/deploy/deploy-all.sh
+```
+
+**Behavior:**
+- Loops through each directory in `examples/`
+- Skips `emdash-templates` (template library, not a deployable site)
+- Calls `deploy.sh` for each site
+- Outputs a summary of all deployments
+
+**Example output:**
+```
+Deploying all EmDash sites to Cloudflare Pages...
+
+[1/3] Deploying bellas-bistro...
+✓ bellas-bistro deployed: https://bellas-bistro.pages.dev
+
+[2/3] Deploying craft-co-studio...
+✓ craft-co-studio deployed: https://craft-co-studio.pages.dev
+
+[3/3] Deploying peak-dental...
+✓ peak-dental deployed: https://peak-dental.pages.dev
+
+===== DEPLOYMENT SUMMARY =====
+Total sites: 3
+Successful: 3
+Failed: 0
+```
+
+## Cloudflare Configuration
+
+### Environment Variables
+
+Set these before running the deploy scripts:
+
+```bash
+export CLOUDFLARE_API_TOKEN="your-cloudflare-api-token"
+export CLOUDFLARE_ACCOUNT_ID="your-cloudflare-account-id"
+```
+
+**Obtaining credentials:**
+- API Token: [Cloudflare Dashboard](https://dash.cloudflare.com/profile/api-tokens) — create a token with "Pages Publish" scope
+- Account ID: [Cloudflare Dashboard](https://dash.cloudflare.com/profile/api-tokens) — visible in account settings
+
+### Project Naming
+
+Cloudflare Pages projects use the project name passed to the deploy script. For consistency:
+- Use lowercase with hyphens (e.g., `bellas-bistro`, `peak-dental`)
+- Project name becomes part of the live URL: `https://{project-name}.pages.dev`
+
+## Architecture
+
+```
+PRD Approved
+    ↓
+[BUILD] astro build → dist/
+    ↓
+[VALIDATE] Check Cloudflare project exists
+    ↓
+[DEPLOY] wrangler pages deploy dist --project-name {name}
+    ↓
+[OUTPUT] https://{name}.pages.dev
+    ↓
+LIVE
+```
+
+## Error Handling
+
+The deploy scripts include validation and error handling:
+
+- **Missing site directory** — Exit with error message
+- **Node version too old** — Exit with version requirement
+- **Build failure** — Exit with Astro error output
+- **Cloudflare authentication** — Exit if API token or account ID missing or invalid
+- **Deployment failure** — Exit with Wrangler error output
+
+## Integration with CI/CD
+
+These scripts are designed to be called from CI/CD pipelines (GitHub Actions, etc.):
+
+```yaml
+# Example GitHub Actions workflow
+- name: Deploy to Cloudflare Pages
+  env:
+    CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+  run: ./pipeline/deploy/deploy.sh ./examples/bellas-bistro bellas-bistro
+```
+
+## Token Usage
+
+Deployments consume no pipeline tokens — they are purely infrastructure cost.
+
+## Next Steps
+
+- [ ] Add GitHub Actions workflow for automatic deployments on main branch
+- [ ] Add preview environment deployments for feature branches
+- [ ] Implement domain routing (e.g., bellas-bistro.com → Cloudflare)
+- [ ] Add analytics and monitoring dashboard

--- a/pipeline/deploy/deploy-all.sh
+++ b/pipeline/deploy/deploy-all.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Print colored output
+print_status() {
+  echo -e "${BLUE}→${NC} $1"
+}
+
+print_success() {
+  echo -e "${GREEN}✓${NC} $1"
+}
+
+print_error() {
+  echo -e "${RED}✗${NC} $1"
+}
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Navigate to repo root (3 levels up: pipeline/deploy/deploy-all.sh)
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../" && pwd)"
+
+print_status "Deploying all EmDash sites to Cloudflare Pages"
+print_status "Repository root: $REPO_ROOT"
+
+EXAMPLES_DIR="$REPO_ROOT/examples"
+
+if [ ! -d "$EXAMPLES_DIR" ]; then
+  print_error "Examples directory not found: $EXAMPLES_DIR"
+  exit 1
+fi
+
+print_success "Examples directory found"
+
+# Count sites
+SITES=($(ls -1d "$EXAMPLES_DIR"/* 2>/dev/null | grep -v "emdash-templates"))
+SITE_COUNT=${#SITES[@]}
+
+if [ $SITE_COUNT -eq 0 ]; then
+  print_error "No deployable sites found in $EXAMPLES_DIR"
+  exit 1
+fi
+
+echo ""
+print_status "Found $SITE_COUNT site(s) to deploy"
+echo ""
+
+# Track deployment results
+SUCCESSFUL=0
+FAILED=0
+FAILED_SITES=()
+
+# Deploy each site
+for i in "${!SITES[@]}"; do
+  SITE_PATH="${SITES[$i]}"
+  SITE_NAME=$(basename "$SITE_PATH")
+
+  # Skip emdash-templates
+  if [ "$SITE_NAME" = "emdash-templates" ]; then
+    print_warning "Skipping template library: $SITE_NAME"
+    continue
+  fi
+
+  CURRENT=$((i + 1))
+
+  echo -e "${BLUE}────────────────────────────────────────${NC}"
+  print_status "[$CURRENT/$SITE_COUNT] Deploying $SITE_NAME..."
+  echo -e "${BLUE}────────────────────────────────────────${NC}"
+  echo ""
+
+  # Deploy the site
+  if "$SCRIPT_DIR/deploy.sh" "$SITE_PATH" "$SITE_NAME"; then
+    SUCCESSFUL=$((SUCCESSFUL + 1))
+  else
+    print_error "Failed to deploy $SITE_NAME"
+    FAILED=$((FAILED + 1))
+    FAILED_SITES+=("$SITE_NAME")
+  fi
+
+  echo ""
+done
+
+# Print summary
+echo ""
+echo -e "${BLUE}════════════════════════════════════════${NC}"
+echo -e "${BLUE}     DEPLOYMENT SUMMARY${NC}"
+echo -e "${BLUE}════════════════════════════════════════${NC}"
+echo ""
+
+print_status "Total sites: $SITE_COUNT"
+print_success "Successful: $SUCCESSFUL"
+
+if [ $FAILED -gt 0 ]; then
+  print_error "Failed: $FAILED"
+  echo ""
+  print_status "Failed sites:"
+  for SITE in "${FAILED_SITES[@]}"; do
+    echo "  - $SITE"
+  done
+  echo ""
+  exit 1
+else
+  print_success "All sites deployed successfully!"
+  echo ""
+  exit 0
+fi

--- a/pipeline/deploy/deploy.sh
+++ b/pipeline/deploy/deploy.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Print colored output
+print_status() {
+  echo -e "${BLUE}→${NC} $1"
+}
+
+print_success() {
+  echo -e "${GREEN}✓${NC} $1"
+}
+
+print_error() {
+  echo -e "${RED}✗${NC} $1"
+}
+
+print_warning() {
+  echo -e "${YELLOW}!${NC} $1"
+}
+
+# Check arguments
+if [ $# -lt 2 ]; then
+  print_error "Missing arguments"
+  echo "Usage: $0 <site-directory> <project-name>"
+  echo "Example: $0 ./examples/bellas-bistro bellas-bistro"
+  exit 1
+fi
+
+SITE_DIR="$1"
+PROJECT_NAME="$2"
+
+print_status "Deploying EmDash site: $PROJECT_NAME"
+print_status "Site directory: $SITE_DIR"
+
+# Validate site directory exists
+if [ ! -d "$SITE_DIR" ]; then
+  print_error "Site directory not found: $SITE_DIR"
+  exit 1
+fi
+
+print_success "Site directory validated"
+
+# Check Node version >= 22
+NODE_VERSION=$(node -v | cut -d'v' -f2 | cut -d'.' -f1)
+if [ "$NODE_VERSION" -lt 22 ]; then
+  print_error "Node.js version 22 or higher required. Current: $(node -v)"
+  exit 1
+fi
+
+print_success "Node.js version validated: $(node -v)"
+
+# Navigate to site directory
+cd "$SITE_DIR"
+
+# Install dependencies if node_modules missing
+if [ ! -d "node_modules" ]; then
+  print_status "Installing dependencies..."
+  npm install
+  print_success "Dependencies installed"
+else
+  print_success "node_modules already exists, skipping install"
+fi
+
+# Build with Astro
+print_status "Building with Astro..."
+if ! npx astro build; then
+  print_error "Astro build failed"
+  exit 1
+fi
+
+print_success "Astro build completed"
+
+# Check if dist directory exists
+if [ ! -d "dist" ]; then
+  print_error "Build output directory not found: dist/"
+  exit 1
+fi
+
+print_success "Build output validated"
+
+# Verify Cloudflare credentials
+if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+  print_error "CLOUDFLARE_API_TOKEN environment variable not set"
+  exit 1
+fi
+
+if [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
+  print_error "CLOUDFLARE_ACCOUNT_ID environment variable not set"
+  exit 1
+fi
+
+print_success "Cloudflare credentials validated"
+
+# Check if Cloudflare Pages project exists
+print_status "Checking if Cloudflare Pages project exists..."
+if npx wrangler pages project list 2>/dev/null | grep -q "^$PROJECT_NAME\$"; then
+  print_success "Cloudflare Pages project exists: $PROJECT_NAME"
+else
+  print_warning "Cloudflare Pages project not found, creating: $PROJECT_NAME"
+  if npx wrangler pages project create "$PROJECT_NAME" 2>/dev/null; then
+    print_success "Cloudflare Pages project created: $PROJECT_NAME"
+  else
+    print_error "Failed to create Cloudflare Pages project: $PROJECT_NAME"
+    exit 1
+  fi
+fi
+
+# Deploy to Cloudflare Pages
+print_status "Deploying to Cloudflare Pages..."
+DEPLOY_OUTPUT=$(npx wrangler pages deploy dist --project-name "$PROJECT_NAME" --branch main 2>&1)
+
+if echo "$DEPLOY_OUTPUT" | grep -q "Deployment ID"; then
+  print_success "Deployment completed"
+
+  # Extract deployment URL from output
+  DEPLOYMENT_URL="https://${PROJECT_NAME}.pages.dev"
+
+  # Try to extract actual deployment URL if available
+  if echo "$DEPLOY_OUTPUT" | grep -q "https://"; then
+    DEPLOYMENT_URL=$(echo "$DEPLOY_OUTPUT" | grep "https://" | head -1 | sed 's/.*\(https:\/\/[^ ]*\).*/\1/')
+  fi
+
+  echo ""
+  echo -e "${GREEN}═══════════════════════════════════════${NC}"
+  print_success "Site deployed successfully!"
+  echo -e "${GREEN}═══════════════════════════════════════${NC}"
+  echo ""
+  print_status "Project: $PROJECT_NAME"
+  print_status "Live URL: $DEPLOYMENT_URL"
+  echo ""
+  exit 0
+else
+  print_error "Deployment failed"
+  echo "$DEPLOY_OUTPUT"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Implements automated deployment pipeline for EmDash sites to Cloudflare Pages.

## Changes

- **pipeline/deploy/README.md** — Comprehensive deployment overview with architecture, configuration, and integration guidelines
- **pipeline/deploy/deploy.sh** — Single-site deployment script:
  - Validates site directory and Node version >= 22
  - Handles npm dependency installation
  - Builds with Astro
  - Creates Cloudflare Pages project if needed
  - Deploys via Wrangler CLI
  - Outputs live production URL
- **pipeline/deploy/deploy-all.sh** — Bulk deployment script:
  - Iterates through all sites in examples/
  - Skips template library (emdash-templates)
  - Provides summary with success/failure tracking

## Requirements

- Node.js >= 22
- Cloudflare API token (CLOUDFLARE_API_TOKEN env var)
- Cloudflare account ID (CLOUDFLARE_ACCOUNT_ID env var)
- Wrangler CLI (installed via npm)

## Usage

Deploy single site:
```bash
./pipeline/deploy/deploy.sh ./examples/bellas-bistro bellas-bistro
```

Deploy all sites:
```bash
./pipeline/deploy/deploy-all.sh
```

Ready for integration into GitHub Actions CI/CD workflows.