### PR TITLE
Increase portfolio screenshot visibility

### DIFF
--- a/website/src/app/work/page.tsx
+++ b/website/src/app/work/page.tsx
@@ -156,7 +156,7 @@ export default function WorkPage() {
                     <img
                       src={project.screenshot}
                       alt={`${project.name} website screenshot`}
-                      className="w-full h-40 object-cover object-top"
+                      className="w-full h-56 object-cover object-top"
                     />
                   </div>
                   <div className="px-8 pb-8 pt-6">


### PR DESCRIPTION
Increase browser mockup screenshot height from h-40 to h-56 for better visibility of project examples in the work page.

Changes:
- Updated img tag className on /src/app/work/page.tsx
- h-40 (160px) → h-56 (224px) for improved readability

Screenshots are already properly configured:
- bellas-bistro.png
- peak-dental.png
- craft-co-studio.png

All three projects now display larger, more visible screenshots.