### PR TITLE
PRD intake: GitHub issues + input sanitization

### DIFF
--- a/workers/contact-form/src/index.ts
+++ b/workers/contact-form/src/index.ts
@@ -1,15 +1,16 @@
 /**
  * Shipyard AI — Contact Form Worker
  *
- * Cloudflare Worker that receives form submissions and sends
- * them via Resend. Deployed separately from the static site.
+ * Cloudflare Worker that receives form submissions, sanitizes input,
+ * sends email via Resend, and creates a GitHub issue for PRD intake.
  *
  * POST /submit — accepts JSON { name, email, projectType, budget, description }
- * Returns 200 on success, 400/500 on error.
+ * Returns 200 on success, 400/429/500 on error.
  */
 
 interface Env {
   RESEND_API_KEY: string;
+  GITHUB_TOKEN: string;
   FROM_EMAIL: string;
   TO_EMAIL: string;
   CORS_ORIGIN: string;
@@ -24,6 +25,64 @@ interface ContactPayload {
   website?: string; // honeypot
 }
 
+// --- Input Sanitization ---
+
+const XSS_PATTERNS = [
+  /<script/i,
+  /javascript:/i,
+  /on\w+\s*=/i,
+  /data:\s*text\/html/i,
+  /vbscript:/i,
+];
+
+function stripHtml(str: string): string {
+  return str.replace(/<[^>]*>/g, "");
+}
+
+function sanitize(str: string, maxLength: number): string {
+  let cleaned = stripHtml(str).trim();
+  if (cleaned.length > maxLength) {
+    cleaned = cleaned.slice(0, maxLength);
+  }
+  return cleaned;
+}
+
+function containsXss(str: string): boolean {
+  return XSS_PATTERNS.some((pattern) => pattern.test(str));
+}
+
+function validateEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(email) && email.length <= 254;
+}
+
+// --- Rate Limiting ---
+
+function getClientIp(request: Request): string {
+  return (
+    request.headers.get("cf-connecting-ip") ||
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    "unknown"
+  );
+}
+
+// Simple in-memory rate limit (resets on worker restart, good enough for edge)
+const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
+const RATE_LIMIT = 5;
+const RATE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const entry = rateLimitMap.get(ip);
+  if (!entry || now > entry.resetAt) {
+    rateLimitMap.set(ip, { count: 1, resetAt: now + RATE_WINDOW_MS });
+    return false;
+  }
+  entry.count++;
+  return entry.count > RATE_LIMIT;
+}
+
+// --- CORS ---
+
 function corsHeaders(origin: string): Record<string, string> {
   return {
     "Access-Control-Allow-Origin": origin,
@@ -32,11 +91,65 @@ function corsHeaders(origin: string): Record<string, string> {
   };
 }
 
+// --- GitHub Issue Creation ---
+
+async function createGitHubIssue(
+  token: string,
+  payload: ContactPayload
+): Promise<boolean> {
+  const title = `PRD: ${payload.projectType} from ${payload.name}`;
+  const body = [
+    `## PRD Intake`,
+    ``,
+    `| Field | Value |`,
+    `|-------|-------|`,
+    `| **Name** | ${payload.name} |`,
+    `| **Email** | ${payload.email} |`,
+    `| **Project Type** | ${payload.projectType} |`,
+    `| **Budget** | ${payload.budget || "Not specified"} |`,
+    ``,
+    `## Project Description / PRD`,
+    ``,
+    payload.description,
+    ``,
+    `---`,
+    `*Submitted via [shipyard.company](https://shipyard.company/contact) contact form*`,
+  ].join("\n");
+
+  const response = await fetch(
+    "https://api.github.com/repos/sethshoultes/shipyard-ai/issues",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "Content-Type": "application/json",
+        "User-Agent": "Shipyard-AI-Worker",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: JSON.stringify({
+        title,
+        body,
+        labels: ["prd-intake"],
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    const err = await response.text();
+    console.error("GitHub issue creation failed:", response.status, err);
+    return false;
+  }
+  return true;
+}
+
+// --- Main Handler ---
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const headers = corsHeaders(env.CORS_ORIGIN);
 
-    // Handle CORS preflight
+    // CORS preflight
     if (request.method === "OPTIONS") {
       return new Response(null, { status: 204, headers });
     }
@@ -48,33 +161,76 @@ export default {
       });
     }
 
+    // Rate limit
+    const ip = getClientIp(request);
+    if (isRateLimited(ip)) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          message: "Too many submissions. Please try again later.",
+        }),
+        { status: 429, headers: { ...headers, "Content-Type": "application/json" } }
+      );
+    }
+
     try {
-      const body: ContactPayload = await request.json();
+      const raw: ContactPayload = await request.json();
 
       // Honeypot check
-      if (body.website) {
+      if (raw.website) {
         return new Response(
-          JSON.stringify({ success: true, message: "Thanks! We'll be in touch within 24 hours." }),
+          JSON.stringify({
+            success: true,
+            message: "Thanks! We'll be in touch within 24 hours.",
+          }),
           { status: 200, headers: { ...headers, "Content-Type": "application/json" } }
         );
       }
 
+      // Sanitize all fields
+      const body: ContactPayload = {
+        name: sanitize(raw.name || "", 100),
+        email: sanitize(raw.email || "", 254),
+        projectType: sanitize(raw.projectType || "", 100),
+        budget: sanitize(raw.budget || "", 100),
+        description: sanitize(raw.description || "", 50_000),
+      };
+
       // Validate required fields
-      if (!body.name?.trim() || !body.email?.trim() || !body.description?.trim()) {
+      if (!body.name || !body.email || !body.description) {
         return new Response(
-          JSON.stringify({ success: false, message: "Please fill in all required fields." }),
+          JSON.stringify({
+            success: false,
+            message: "Please fill in all required fields.",
+          }),
           { status: 400, headers: { ...headers, "Content-Type": "application/json" } }
         );
       }
 
-      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(body.email)) {
+      // Validate email format
+      if (!validateEmail(body.email)) {
         return new Response(
-          JSON.stringify({ success: false, message: "Please enter a valid email address." }),
+          JSON.stringify({
+            success: false,
+            message: "Please enter a valid email address.",
+          }),
           { status: 400, headers: { ...headers, "Content-Type": "application/json" } }
         );
       }
 
-      // Send via Resend
+      // XSS check across all fields
+      const allInput = `${body.name} ${body.email} ${body.projectType} ${body.budget} ${body.description}`;
+      if (containsXss(allInput)) {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            message: "Invalid input detected.",
+          }),
+          { status: 400, headers: { ...headers, "Content-Type": "application/json" } }
+        );
+      }
+
+      // Send email via Resend
       const resendResponse = await fetch("https://api.resend.com/emails", {
         method: "POST",
         headers: {
@@ -104,13 +260,28 @@ export default {
         const err = await resendResponse.text();
         console.error("Resend error:", err);
         return new Response(
-          JSON.stringify({ success: false, message: "Failed to send. Please email us directly at hello@shipyard.company." }),
+          JSON.stringify({
+            success: false,
+            message:
+              "Failed to send. Please email us directly at hello@shipyard.company.",
+          }),
           { status: 500, headers: { ...headers, "Content-Type": "application/json" } }
         );
       }
 
+      // Create GitHub issue (non-blocking — don't fail the response if this errors)
+      if (env.GITHUB_TOKEN) {
+        createGitHubIssue(env.GITHUB_TOKEN, body).catch((err) => {
+          console.error("GitHub issue creation error:", err);
+        });
+      }
+
       return new Response(
-        JSON.stringify({ success: true, message: "Thanks! We'll scope your project and respond within 24 hours." }),
+        JSON.stringify({
+          success: true,
+          message:
+            "Thanks! We'll scope your project and respond within 24 hours.",
+        }),
         { status: 200, headers: { ...headers, "Content-Type": "application/json" } }
       );
     } catch {


### PR DESCRIPTION
## Summary
- Contact form submissions now create GitHub issues with label `prd-intake` in addition to sending email via Resend
- Added comprehensive input sanitization: HTML stripping, field length limits, XSS pattern detection
- Added rate limiting: 5 submissions per IP per hour
- GitHub issue creation is non-blocking (fire-and-forget) — email is the critical path

## Changes
- `workers/contact-form/src/index.ts` — sanitization layer, GitHub API integration, rate limiting
- Worker redeployed to `shipyard-contact.seth-a02.workers.dev` with `GITHUB_TOKEN` binding

## Test plan
- [x] Worker deploys successfully with both env vars
- [x] `prd-intake` label created on GitHub repo
- [ ] Submit test form on shipyard.company → verify email received AND GitHub issue created
- [ ] Submit with `<script>alert(1)</script>` in name → verify 400 rejection
- [ ] Submit 6 times from same IP → verify 429 on 6th attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)