### PR TITLE
feat: add /parse and /generate-seed endpoints to prd-chat worker

### DIFF
--- a/workers/prd-chat/package.json
+++ b/workers/prd-chat/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "shipyard-prd-chat",
+  "version": "0.1.0",
+  "description": "Cloudflare Worker for PRD parsing and seed generation",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240605.0",
+    "typescript": "^5.3.3",
+    "wrangler": "^3.30.0"
+  }
+}

--- a/workers/prd-chat/src/index.ts
+++ b/workers/prd-chat/src/index.ts
@@ -1,0 +1,450 @@
+/**
+ * Shipyard AI — PRD Chat Worker
+ *
+ * Cloudflare Worker that handles PRD parsing and seed generation.
+ * Uses Workers AI to extract structured data from raw PRD text.
+ *
+ * POST /chat — existing endpoint (if needed)
+ * POST /parse — extract structured PRD data
+ * POST /generate-seed — convert structured PRD to EmDash seed.json
+ */
+
+interface Env {
+  AI: Ai;
+  CORS_ORIGIN: string;
+}
+
+interface ParseRequest {
+  prd: string;
+}
+
+interface StructuredPRD {
+  businessName: string;
+  vertical: string;
+  tagline: string;
+  heroHeadline: string;
+  heroSubheadline: string;
+  features: Array<{
+    icon: string;
+    title: string;
+    description: string;
+  }>;
+  testimonials: Array<{
+    quote: string;
+    author: string;
+    role: string;
+    company: string;
+  }>;
+  faqItems: Array<{
+    question: string;
+    answer: string;
+  }>;
+  pages: string[];
+  primaryCta: {
+    label: string;
+    url: string;
+  };
+  secondaryCta: {
+    label: string;
+    url: string;
+  };
+}
+
+interface SeedRequest {
+  businessName: string;
+  vertical: string;
+  tagline: string;
+  heroHeadline: string;
+  heroSubheadline: string;
+  features: Array<{
+    icon: string;
+    title: string;
+    description: string;
+  }>;
+  testimonials: Array<{
+    quote: string;
+    author: string;
+    role: string;
+    company: string;
+  }>;
+  faqItems: Array<{
+    question: string;
+    answer: string;
+  }>;
+  pages: string[];
+  primaryCta: {
+    label: string;
+    url: string;
+  };
+  secondaryCta: {
+    label: string;
+    url: string;
+  };
+}
+
+const MAX_PRD_LENGTH = 50_000;
+
+const XSS_PATTERNS = [
+  /<script[\s>]/i,
+  /javascript:/i,
+  /on\w+\s*=/i,
+  /data:\s*text\/html/i,
+];
+
+function stripHtml(str: string): string {
+  return str.replace(/<[^>]*>/g, "");
+}
+
+function sanitizePrd(str: string): string {
+  return stripHtml(str).trim().slice(0, MAX_PRD_LENGTH);
+}
+
+function containsXss(str: string): boolean {
+  return XSS_PATTERNS.some((pattern) => pattern.test(str));
+}
+
+function corsHeaders(origin: string): Record<string, string> {
+  return {
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  };
+}
+
+function isValidStructuredPRD(data: unknown): data is StructuredPRD {
+  if (typeof data !== "object" || data === null) return false;
+  const obj = data as Record<string, unknown>;
+
+  return (
+    typeof obj.businessName === "string" &&
+    typeof obj.vertical === "string" &&
+    typeof obj.tagline === "string" &&
+    typeof obj.heroHeadline === "string" &&
+    typeof obj.heroSubheadline === "string" &&
+    Array.isArray(obj.features) &&
+    Array.isArray(obj.testimonials) &&
+    Array.isArray(obj.faqItems) &&
+    Array.isArray(obj.pages) &&
+    typeof obj.primaryCta === "object" &&
+    typeof obj.secondaryCta === "object"
+  );
+}
+
+function generateSeedJson(data: SeedRequest): string {
+  const slug = data.businessName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+
+  const seed = {
+    $schema: "https://emdashcms.com/seed.schema.json",
+    version: "1",
+    meta: {
+      name: data.businessName,
+      description: data.tagline,
+      author: "Shipyard AI",
+    },
+    settings: {
+      title: data.businessName,
+      tagline: data.tagline,
+    },
+    collections: [
+      {
+        slug: "pages",
+        label: "Pages",
+        labelSingular: "Page",
+        supports: ["drafts", "revisions", "seo"],
+        fields: [
+          {
+            slug: "title",
+            label: "Title",
+            type: "string",
+            required: true,
+          },
+          {
+            slug: "content",
+            label: "Content",
+            type: "portableText",
+          },
+        ],
+      },
+    ],
+    menus: [
+      {
+        name: "primary",
+        label: "Primary Navigation",
+        items: [
+          { type: "custom", label: "Home", url: "/" },
+          ...(data.pages.includes("pricing")
+            ? [{ type: "custom", label: "Services", url: "/pricing" }]
+            : []),
+          ...(data.pages.includes("contact")
+            ? [{ type: "custom", label: "Contact", url: "/contact" }]
+            : []),
+        ],
+      },
+    ],
+    content: {
+      pages: [
+        {
+          id: "home",
+          slug: "home",
+          status: "published",
+          data: {
+            title: "Home",
+            content: [
+              {
+                _type: "marketing.hero",
+                _key: "hero",
+                headline: data.heroHeadline,
+                subheadline: data.heroSubheadline,
+                primaryCta: data.primaryCta,
+                secondaryCta: data.secondaryCta,
+              },
+              {
+                _type: "marketing.features",
+                _key: "features",
+                headline: "Why choose us",
+                subheadline: "What makes us different",
+                features: data.features,
+              },
+              ...(data.testimonials.length > 0
+                ? [
+                    {
+                      _type: "marketing.testimonials",
+                      _key: "testimonials",
+                      headline: "What our clients say",
+                      testimonials: data.testimonials,
+                    },
+                  ]
+                : []),
+              ...(data.faqItems.length > 0
+                ? [
+                    {
+                      _type: "marketing.faq",
+                      _key: "faq",
+                      headline: "Frequently asked",
+                      items: data.faqItems,
+                    },
+                  ]
+                : []),
+            ],
+          },
+        },
+        ...(data.pages.includes("pricing")
+          ? [
+              {
+                id: "pricing",
+                slug: "pricing",
+                status: "published",
+                data: {
+                  title: "Services",
+                  content: [
+                    {
+                      _type: "marketing.hero",
+                      _key: "pricing-hero",
+                      headline: "Our Services",
+                      subheadline: data.tagline,
+                      centered: true,
+                    },
+                  ],
+                },
+              },
+            ]
+          : []),
+        ...(data.pages.includes("contact")
+          ? [
+              {
+                id: "contact",
+                slug: "contact",
+                status: "published",
+                data: {
+                  title: "Contact",
+                  content: [
+                    {
+                      _type: "marketing.hero",
+                      _key: "contact-hero",
+                      headline: "Get in touch",
+                      subheadline: "We'd love to hear from you.",
+                      centered: true,
+                    },
+                  ],
+                },
+              },
+            ]
+          : []),
+      ],
+    },
+  };
+
+  return JSON.stringify(seed, null, 2);
+}
+
+async function parseWithAI(
+  ai: Ai,
+  prdText: string
+): Promise<StructuredPRD | null> {
+  try {
+    const systemPrompt =
+      'Extract the following from this PRD and return valid JSON only, no other text: { businessName, vertical (restaurant/dental/salon/services/portfolio/other), tagline, heroHeadline, heroSubheadline, features: [{icon, title, description}], testimonials: [{quote, author, role, company}], faqItems: [{question, answer}], pages: [home/pricing/contact], primaryCta: {label, url}, secondaryCta: {label, url} }';
+
+    const response = await ai.run("@cf/meta/llama-2-7b-chat-int8", {
+      prompt: `${systemPrompt}\n\nPRD Text:\n${prdText}`,
+    });
+
+    if (!response || typeof response.response !== "string") {
+      console.error("Invalid AI response format", response);
+      return null;
+    }
+
+    // Extract JSON from the response
+    const jsonMatch = response.response.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      console.error("No JSON found in AI response", response.response);
+      return null;
+    }
+
+    const parsed = JSON.parse(jsonMatch[0]);
+
+    if (!isValidStructuredPRD(parsed)) {
+      console.error("Invalid structured PRD format", parsed);
+      return null;
+    }
+
+    return parsed;
+  } catch (error) {
+    console.error("AI parsing error:", error);
+    return null;
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const headers = corsHeaders(env.CORS_ORIGIN);
+    const url = new URL(request.url);
+
+    // Handle CORS preflight
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers });
+    }
+
+    // Parse endpoint
+    if (url.pathname === "/parse" && request.method === "POST") {
+      try {
+        const body: ParseRequest = await request.json();
+
+        if (!body.prd || typeof body.prd !== "string") {
+          return new Response(
+            JSON.stringify({ error: "Missing or invalid 'prd' field" }),
+            {
+              status: 400,
+              headers: { ...headers, "Content-Type": "application/json" },
+            }
+          );
+        }
+
+        // Sanitize input
+        const sanitizedPrd = sanitizePrd(body.prd);
+
+        if (containsXss(sanitizedPrd)) {
+          return new Response(
+            JSON.stringify({ error: "Invalid input detected" }),
+            {
+              status: 400,
+              headers: { ...headers, "Content-Type": "application/json" },
+            }
+          );
+        }
+
+        // Use Workers AI to extract structured data
+        const result = await parseWithAI(env.AI, sanitizedPrd);
+
+        if (!result) {
+          return new Response(
+            JSON.stringify({
+              error: "Failed to parse PRD. Please ensure it contains the required information.",
+            }),
+            {
+              status: 400,
+              headers: { ...headers, "Content-Type": "application/json" },
+            }
+          );
+        }
+
+        return new Response(JSON.stringify(result), {
+          status: 200,
+          headers: { ...headers, "Content-Type": "application/json" },
+        });
+      } catch (error) {
+        console.error("Parse endpoint error:", error);
+        return new Response(
+          JSON.stringify({ error: "Invalid request" }),
+          {
+            status: 400,
+            headers: { ...headers, "Content-Type": "application/json" },
+          }
+        );
+      }
+    }
+
+    // Generate seed endpoint
+    if (url.pathname === "/generate-seed" && request.method === "POST") {
+      try {
+        const body: SeedRequest = await request.json();
+
+        if (!isValidStructuredPRD(body)) {
+          return new Response(
+            JSON.stringify({
+              error: "Invalid structured PRD format. Missing required fields.",
+            }),
+            {
+              status: 400,
+              headers: { ...headers, "Content-Type": "application/json" },
+            }
+          );
+        }
+
+        const seedJson = generateSeedJson(body);
+
+        return new Response(
+          JSON.stringify({
+            seed: JSON.parse(seedJson),
+            seedJson,
+          }),
+          {
+            status: 200,
+            headers: { ...headers, "Content-Type": "application/json" },
+          }
+        );
+      } catch (error) {
+        console.error("Generate seed endpoint error:", error);
+        return new Response(
+          JSON.stringify({ error: "Invalid request" }),
+          {
+            status: 400,
+            headers: { ...headers, "Content-Type": "application/json" },
+          }
+        );
+      }
+    }
+
+    // Chat endpoint (placeholder for existing functionality)
+    if (url.pathname === "/chat" && request.method === "POST") {
+      return new Response(
+        JSON.stringify({ message: "Chat endpoint - coming soon" }),
+        {
+          status: 200,
+          headers: { ...headers, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({ error: "Not found" }),
+      {
+        status: 404,
+        headers: { ...headers, "Content-Type": "application/json" },
+      }
+    );
+  },
+};

--- a/workers/prd-chat/tsconfig.json
+++ b/workers/prd-chat/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "lib": ["ES2020"],
+    "types": ["@cloudflare/workers-types"],
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/workers/prd-chat/wrangler.toml
+++ b/workers/prd-chat/wrangler.toml
@@ -1,0 +1,9 @@
+name = "shipyard-prd-chat"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+
+[env.production]
+route = "prd-api.shipyard.company/*"
+
+[vars]
+CORS_ORIGIN = "https://shipyard.company"


### PR DESCRIPTION
Implements two new endpoints for the PRD chat worker:

## POST /parse
- Accepts raw PRD text from GitHub issues
- Uses Workers AI (Llama 2) to extract structured data
- Returns JSON with: businessName, vertical, tagline, hero content, features, testimonials, FAQs, pages, CTAs
- Sanitizes input (strips HTML, limits to 50k chars)

## POST /generate-seed
- Accepts structured PRD data from /parse
- Generates complete EmDash seed.json based on Bella's Bistro template
- Creates home page with hero, features, testimonials, FAQ sections
- Conditionally creates pricing and contact pages based on input
- Outputs both parsed object and JSON string

## Changes
- Full TypeScript types and validation
- CORS support with configurable origin
- Input sanitization (XSS prevention)
- /chat endpoint as placeholder for future functionality
- Deployed to Cloudflare Workers: https://shipyard-prd-chat.seth-a02.workers.dev

This enables the agency to automatically convert raw PRD intake into structured marketing site seeds.